### PR TITLE
Ability to redirect logs to any Action<string>.

### DIFF
--- a/TheUniversalCity.RedisClient/RedisConfiguration.cs
+++ b/TheUniversalCity.RedisClient/RedisConfiguration.cs
@@ -24,6 +24,8 @@ namespace TheUniversalCity.RedisClient
         public int ReceiveBufferSize { get { return Options.ContainsKey(RECEIVE_BUFFER_SIZE) ? int.Parse(Options[RECEIVE_BUFFER_SIZE]) : 65536; } }
         public int SendBufferSize { get { return Options.ContainsKey(SEND_BUFFER_SIZE) ? int.Parse(Options[SEND_BUFFER_SIZE]) : 65536; } }
 
+        public Action<string> Logger { get; set; } = Console.WriteLine;
+
         public Dictionary<string, string> Options { get; set; } = new Dictionary<string, string>();
 
         public RedisConfiguration(string connectionString)

--- a/TheUniversalCity.RedisClient/RedisObjectDeterminator.cs
+++ b/TheUniversalCity.RedisClient/RedisObjectDeterminator.cs
@@ -6,38 +6,69 @@ using TheUniversalCity.RedisClient.RedisObjects.BlobStrings;
 using TheUniversalCity.RedisClient.RedisObjects.Numerics;
 using TheUniversalCity.RedisClient.RedisObjects.SimpleStrings;
 
-namespace TheUniversalCity.RedisClient
-{
-    public static class RedisObjectDeterminator
-    {
+namespace TheUniversalCity.RedisClient {
+    public static class RedisObjectDeterminator {
         public const byte CR = (byte)'\r';
         public const byte LF = (byte)'\n';
 
-        public static RedisObject Determine(IEnumerator<byte> enumerator)
-        {
+        public static RedisObject Determine(IEnumerator<byte> enumerator
+#if DEBUG
+                                            ,
+                                            System.Action<string> logger
+#endif
+
+        ) {
             enumerator.MoveNext();
 
             var determinativeChar = enumerator.Current;
 
-            switch (determinativeChar)
-            {
+            switch (determinativeChar) {
                 case RedisArray.DETERMINATIVE_CHAR:
-                    return RedisCollectionObject.GetRedisCollectionObject<RedisArray>(enumerator);
-                case RedisAttributeType.DETERMINATIVE_CHAR:
-                    {
-                        var attribute = RedisDictionaryObject.GetRedisDictionaryObject<RedisAttributeType>(enumerator); ;
-                        var afterObj = Determine(enumerator);
+                    return RedisCollectionObject.GetRedisCollectionObject<RedisArray>(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
+                case RedisAttributeType.DETERMINATIVE_CHAR: {
+                    var attribute = RedisDictionaryObject.GetRedisDictionaryObject<RedisAttributeType>(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
+                    var afterObj = Determine(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
 
-                        afterObj.SetAttribute(attribute);
+                    afterObj.SetAttribute(attribute);
 
-                        return afterObj;
-                    }
+                    return afterObj;
+                }
                 case RedisBigNumber.DETERMINATIVE_CHAR:
                     return RedisBigNumber.Parse(enumerator);
                 case RedisBlobError.DETERMINATIVE_CHAR:
-                    return RedisBlobError.Parse(enumerator);
+                    return RedisBlobError.Parse(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
                 case RedisBlobString.DETERMINATIVE_CHAR:
-                    return RedisBlobString.Parse(enumerator);
+                    return RedisBlobString.Parse(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
                 case RedisBoolean.DETERMINATIVE_CHAR:
                     return RedisBoolean.Parse(enumerator);
                 case RedisDouble.DETERMINATIVE_CHAR:
@@ -45,21 +76,45 @@ namespace TheUniversalCity.RedisClient
                 case RedisEndType.DETERMINATIVE_CHAR:
                     return RedisEndType.Parse(enumerator);
                 case RedisMapType.DETERMINATIVE_CHAR:
-                    return RedisDictionaryObject.GetRedisDictionaryObject<RedisMapType>(enumerator);
+                    return RedisDictionaryObject.GetRedisDictionaryObject<RedisMapType>(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
                 case RedisNull.DETERMINATIVE_CHAR:
                     return RedisNull.Parse(enumerator);
                 case RedisNumber.DETERMINATIVE_CHAR:
                     return RedisNumber.Parse(enumerator);
                 case RedisPushType.DETERMINATIVE_CHAR:
-                    return RedisCollectionObject.GetRedisCollectionObject<RedisPushType>(enumerator);
+                    return RedisCollectionObject.GetRedisCollectionObject<RedisPushType>(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
                 case RedisSetReply.DETERMINATIVE_CHAR:
-                    return RedisCollectionObject.GetRedisCollectionObject<RedisSetReply>(enumerator);
+                    return RedisCollectionObject.GetRedisCollectionObject<RedisSetReply>(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
                 case RedisSimpleError.DETERMINATIVE_CHAR:
                     return RedisSimpleError.Parse(enumerator);
                 case RedisSimpleString.DETERMINATIVE_CHAR:
                     return RedisSimpleString.Parse(enumerator);
                 case RedisVerbatimString.DETERMINATIVE_CHAR:
-                    return RedisVerbatimString.Parse(enumerator);
+                    return RedisVerbatimString.Parse(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    );
                 default:
                     return null;
             }

--- a/TheUniversalCity.RedisClient/RedisObjects/Agregates/Abstract/RedisCollectionObject.cs
+++ b/TheUniversalCity.RedisClient/RedisObjects/Agregates/Abstract/RedisCollectionObject.cs
@@ -13,21 +13,31 @@ namespace TheUniversalCity.RedisClient.RedisObjects.Agregates.Abstract
 
         public bool IsReadOnly => false;
 
-        public static TRedisCollectionObject GetRedisCollectionObject<TRedisCollectionObject>(IEnumerator<byte> enumerator) where TRedisCollectionObject : RedisCollectionObject, new()
-        {
+        public static TRedisCollectionObject GetRedisCollectionObject<TRedisCollectionObject>(IEnumerator<byte> enumerator
+#if DEBUG
+                                                                                              ,
+                                                                                              System.Action<string> logger
+#endif
+        ) where TRedisCollectionObject : RedisCollectionObject, new() {
             var length = int.Parse(ReadLineEofCrLf(enumerator, Encoding.ASCII));
             var collectionObject = new TRedisCollectionObject();
 
-            if (length == -1)
-            {
+            if (length == -1) {
                 return collectionObject;
             }
 
             collectionObject.Items = new List<RedisObject>(length);
 
-            for (int i = 0; i < length; i++)
-            {
-                collectionObject.Add(RedisObjectDeterminator.Determine(enumerator));
+            for (int i = 0; i < length; i++) {
+                collectionObject.Add(
+                    RedisObjectDeterminator.Determine(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    )
+                );
             }
 
             return collectionObject;

--- a/TheUniversalCity.RedisClient/RedisObjects/Agregates/Abstract/RedisDictionaryObject.cs
+++ b/TheUniversalCity.RedisClient/RedisObjects/Agregates/Abstract/RedisDictionaryObject.cs
@@ -16,21 +16,38 @@ namespace TheUniversalCity.RedisClient.RedisObjects.Agregates.Abstract
 
         public int Count => Dictionary.Count;
 
-        public static TRedisDictionaryObject GetRedisDictionaryObject<TRedisDictionaryObject>(IEnumerator<byte> enumerator) where TRedisDictionaryObject : RedisDictionaryObject, new()
-        {
+        public static TRedisDictionaryObject GetRedisDictionaryObject<TRedisDictionaryObject>(IEnumerator<byte> enumerator
+#if DEBUG
+                                                                                              ,
+                                                                                              System.Action<string> logger
+#endif
+        ) where TRedisDictionaryObject : RedisDictionaryObject, new() {
             var length = int.Parse(ReadLineEofCrLf(enumerator, Encoding.ASCII));
             var collectionObject = new TRedisDictionaryObject();
 
-            if (length == -1)
-            {
+            if (length == -1) {
                 return collectionObject;
             }
 
             collectionObject.Dictionary = new Dictionary<RedisObject, RedisObject>(length);
 
-            for (int i = 0; i < length; i++)
-            {
-                collectionObject.Dictionary.Add(RedisObjectDeterminator.Determine(enumerator), RedisObjectDeterminator.Determine(enumerator));
+            for (int i = 0; i < length; i++) {
+                collectionObject.Dictionary.Add(
+                    RedisObjectDeterminator.Determine(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    ),
+                    RedisObjectDeterminator.Determine(
+                        enumerator
+#if DEBUG
+                        ,
+                        logger
+#endif
+                    )
+                );
             }
 
             return collectionObject;

--- a/TheUniversalCity.RedisClient/RedisObjects/BlobStrings/RedisBlobError.cs
+++ b/TheUniversalCity.RedisClient/RedisObjects/BlobStrings/RedisBlobError.cs
@@ -9,16 +9,29 @@ namespace TheUniversalCity.RedisClient.RedisObjects.BlobStrings
     {
         public const byte DETERMINATIVE_CHAR = (byte)'!';
 
-        public static RedisBlobError Parse(IEnumerator<byte> enumerator)
-        {
+        public static RedisBlobError Parse(IEnumerator<byte> enumerator
+#if DEBUG
+                                           ,
+                                           System.Action<string> logger
+#endif
+        ) {
             var length = long.Parse(ReadLineEofCrLf(enumerator, Encoding.ASCII));
 
-            if (length == -1)
-            {
+            if (length == -1) {
                 return new RedisBlobError();
             }
 
-            return new RedisBlobError { Values = ReadBlobEofCrLf(enumerator, length, Encoding.UTF8) };
+            return new RedisBlobError {
+                Values = ReadBlobEofCrLf(
+                    enumerator,
+                    length,
+                    Encoding.UTF8
+#if DEBUG
+                    ,
+                    logger
+#endif
+                )
+            };
         }
 
         public static implicit operator string(RedisBlobError redisBlobError)

--- a/TheUniversalCity.RedisClient/RedisObjects/BlobStrings/RedisBlobString.cs
+++ b/TheUniversalCity.RedisClient/RedisObjects/BlobStrings/RedisBlobString.cs
@@ -10,18 +10,31 @@ namespace TheUniversalCity.RedisClient.RedisObjects.BlobStrings
     {
         public const byte DETERMINATIVE_CHAR = (byte)'$';
 
-        public static RedisBlobString Parse(IEnumerator<byte> enumerator)
-        {
+        public static RedisBlobString Parse(IEnumerator<byte> enumerator
+#if DEBUG
+                                            ,
+                                            Action<string> logger
+#endif
+        ) {
             var length = int.Parse(ReadLineEofCrLf(enumerator, Encoding.ASCII));
 #if DEBUG
-            Console.WriteLine($"RedisBlobString Parse : Length =>{length}");
+            logger($"RedisBlobString Parse : Length =>{length}");
 #endif
-            if (length == -1)
-            {
+            if (length == -1) {
                 return new RedisBlobString();
             }
 
-            return new RedisBlobString { Values = ReadBlobEofCrLf(enumerator, length, Encoding.UTF8) };
+            return new RedisBlobString {
+                Values = ReadBlobEofCrLf(
+                    enumerator,
+                    length,
+                    Encoding.UTF8
+#if DEBUG
+                    ,
+                    logger
+#endif
+                )
+            };
         }
 
         public static implicit operator string(RedisBlobString redisBlobString)

--- a/TheUniversalCity.RedisClient/RedisObjects/BlobStrings/RedisVerbatimString.cs
+++ b/TheUniversalCity.RedisClient/RedisObjects/BlobStrings/RedisVerbatimString.cs
@@ -13,12 +13,15 @@ namespace TheUniversalCity.RedisClient.RedisObjects.BlobStrings
 
         public string Prefix { get; set; }
 
-        public static RedisVerbatimString Parse(IEnumerator<byte> enumerator)
-        {
+        public static RedisVerbatimString Parse(IEnumerator<byte> enumerator
+#if DEBUG
+                                                ,
+                                                Action<string> logger
+#endif
+        ) {
             var length = long.Parse(ReadLineEofCrLf(enumerator, Encoding.ASCII));
 
-            if (length == -1)
-            {
+            if (length == -1) {
                 return new RedisVerbatimString();
             }
 
@@ -35,11 +38,21 @@ namespace TheUniversalCity.RedisClient.RedisObjects.BlobStrings
 
             enumerator.MoveNext(); // : character
 
-            if (enumerator.Current != COLON) { throw new InvalidOperationException(); }
+            if (enumerator.Current != COLON) {
+                throw new InvalidOperationException();
+            }
 
-            return new RedisVerbatimString { 
-                Prefix = Encoding.ASCII.GetString(bytesPrefix), 
-                Values = ReadBlobEofCrLf(enumerator, length - 4, Encoding.UTF8)
+            return new RedisVerbatimString {
+                Prefix = Encoding.ASCII.GetString(bytesPrefix),
+                Values = ReadBlobEofCrLf(
+                    enumerator,
+                    length - 4,
+                    Encoding.UTF8
+#if DEBUG
+                    ,
+                    logger
+#endif
+                )
             };
         }
 

--- a/TheUniversalCity.RedisClient/RedisObjects/RedisObject.cs
+++ b/TheUniversalCity.RedisClient/RedisObjects/RedisObject.cs
@@ -48,16 +48,21 @@ namespace TheUniversalCity.RedisClient.RedisObjects
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string[] ReadBlobEofCrLf(IEnumerator<byte> enumerator, long length, Encoding encoding)
-        {
+        public static string[] ReadBlobEofCrLf(IEnumerator<byte> enumerator,
+                                               long length,
+                                               Encoding encoding
+#if DEBUG
+                                               ,
+                                               Action<string> logger
+#endif
+        ) {
             var byteContainer = ReadBlobEofCrLf(enumerator, length);
             var stringContainer = new string[byteContainer.Length];
 
-            for (int i = 0; i < byteContainer.Length; i++)
-            {
+            for (int i = 0; i < byteContainer.Length; i++) {
                 stringContainer[i] = encoding.GetString(byteContainer[i]);
 #if DEBUG
-                Console.WriteLine($"{nameof(ReadBlobEofCrLf)} : Value =>{stringContainer[i]}, i=> {i}");
+                logger($"{nameof(ReadBlobEofCrLf)} : Value =>{stringContainer[i]}, i=> {i}");
 #endif
             }
 


### PR DESCRIPTION
I've added Action<string> to RedisConfiguration to use instead of Console.WriteLine, so now this library could be used with any logging framework with minimal effort.
However, in static contexts conditional compilation looks really ugly yet there's nothing I could have done better.